### PR TITLE
Reload page only after all files are uploaded

### DIFF
--- a/container/interactive/IJulia/tornado/www/upload.tpl
+++ b/container/interactive/IJulia/tornado/www/upload.tpl
@@ -70,7 +70,7 @@ font-size: 2em;
         var jDropzone = new Dropzone("#juliadropzone", { 
                             url: "file-upload",
                             init: function() {
-                                this.on("complete", function(file) { 
+                                this.on("queuecomplete", function(file) { 
                                             window.setTimeout(function() {
                                                     location.reload(); 
                                                 }, 3000);


### PR DESCRIPTION
Change event from `complete` to `queuecomplete`.  This event is triggered only after all files are uploaded.