### PR TITLE
Log response when access token is missing, show appropriate error message

### DIFF
--- a/engine/src/juliabox/plugins/auth_github/github_auth.py
+++ b/engine/src/juliabox/plugins/auth_github/github_auth.py
@@ -64,6 +64,11 @@ class GitHubAuthHandler(JBPluginHandler, OAuth2Mixin):
         code = self.get_argument('code', False)
         if code is not False:
             user = yield self.get_authenticated_user(redirect_uri=self_redirect_uri, code=code)
+            if not user:
+                self.rendertpl("index.tpl", cfg=JBoxCfg.nv, state=self.state(
+                    error="Could not retrieve your access token.  Please try again.",
+                    success=""))
+                return
             user_info = yield self.get_user_info(user)
             if not user_info.get('email'):
                 self.rendertpl("index.tpl", cfg=JBoxCfg.nv, state=self.state(
@@ -127,6 +132,11 @@ class GitHubAuthHandler(JBPluginHandler, OAuth2Mixin):
             return
         args = dict()
         tornado.httputil.parse_body_arguments(response.headers.get("Content-Type"), response.body, args, None)
+        if not args.has_key('access_token'):
+            GitHubAuthHandler.log_error('Key `access_token` not found in response: %r',
+                                        args)
+            future.set_result(None)
+            return
         args['access_token'] = args['access_token'][0]
         args['token_type'] = args['token_type'][0]
         future.set_result(args)

--- a/engine/src/juliabox/plugins/auth_github/github_auth.py
+++ b/engine/src/juliabox/plugins/auth_github/github_auth.py
@@ -66,7 +66,7 @@ class GitHubAuthHandler(JBPluginHandler, OAuth2Mixin):
             user = yield self.get_authenticated_user(redirect_uri=self_redirect_uri, code=code)
             if not user:
                 self.rendertpl("index.tpl", cfg=JBoxCfg.nv, state=self.state(
-                    error="Could not retrieve your access token.  Please try again.",
+                    error="GitHub authentication failed due to unexpected error.  Please try again.",
                     success=""))
                 return
             user_info = yield self.get_user_info(user)

--- a/engine/src/juliabox/plugins/auth_github/github_auth.py
+++ b/engine/src/juliabox/plugins/auth_github/github_auth.py
@@ -133,8 +133,8 @@ class GitHubAuthHandler(JBPluginHandler, OAuth2Mixin):
         args = dict()
         tornado.httputil.parse_body_arguments(response.headers.get("Content-Type"), response.body, args, None)
         if not args.has_key('access_token'):
-            GitHubAuthHandler.log_error('Key `access_token` not found in response: %r',
-                                        args)
+            GitHubAuthHandler.log_error('Key `access_token` not found in response: %r\nResponse body: %r\nResponse headers: %r',
+                                        args, response.body, response.headers)
             future.set_result(None)
             return
         args['access_token'] = args['access_token'][0]


### PR DESCRIPTION
Log response when `access_token` is missing in GitHub authentication response.  Show appropriate error message.