### PR TITLE
Extend OAuth2Mixin instead of GoogleOAuth2Mixin in google auth plugin for better access to debugging information.

### DIFF
--- a/engine/src/juliabox/plugins/auth_github/github_auth.py
+++ b/engine/src/juliabox/plugins/auth_github/github_auth.py
@@ -133,8 +133,8 @@ class GitHubAuthHandler(JBPluginHandler, OAuth2Mixin):
         args = dict()
         tornado.httputil.parse_body_arguments(response.headers.get("Content-Type"), response.body, args, None)
         if not args.has_key('access_token'):
-            GitHubAuthHandler.log_error('Key `access_token` not found in response: %r\nResponse body: %r\nResponse headers: %r',
-                                        args, response.body, response.headers)
+            GitHubAuthHandler.log_error('GitHub auth error: Key `access_token` not found in response: %r\nResponse body: %r\nResponse headers: %r',
+                                        args, response.body, list(response.headers.get_all()))
             future.set_result(None)
             return
         args['access_token'] = args['access_token'][0]


### PR DESCRIPTION
This lets us log the response object when an error occurs during OAuth.  With `GoogleOAuth2Mixin` the response is handled by the library and not accessible to us.

Tested login and google drive.