### PR TITLE
Increase chunk size in Google Storage plugin

### DIFF
--- a/engine/src/juliabox/plugins/bucket_gs/impl_gs.py
+++ b/engine/src/juliabox/plugins/bucket_gs/impl_gs.py
@@ -28,10 +28,12 @@ class JBoxGS(JBPluginCloud):
     MAX_BACKOFF = 32
     BACKOFF_FACTOR = 2
     SLEEP_TIME = 3
+    CHUNK_SIZE = 64
 
     @staticmethod
     def configure():
-        JBoxGS.MAX_RETRIES = JBoxCfg.get('bucket_gs.max_retries', 10)
+        JBoxGS.MAX_RETRIES = JBoxCfg.get('bucket_gs.max_retries', JBoxGS.MAX_RETRIES)
+        JBoxGS.CHUNK_SIZE = JBoxCfg.get('bucket_gs.chunk_size', JBoxGS.CHUNK_SIZE)
 
     @staticmethod
     def connect():
@@ -62,7 +64,7 @@ class JBoxGS(JBPluginCloud):
         objconn = JBoxGS.connect().objects()
         fh = open(local_file, "rb")
         media = MediaIoBaseUpload(fh, JBoxGS._get_mime_type(local_file),
-                                  resumable=True, chunksize=4*1024*1024)
+                                  resumable=True, chunksize=JBoxGS.CHUNK_SIZE*1024*1024)
         uploader = None
         if metadata:
             uploader = objconn.insert(bucket=bucket, media_body=media,
@@ -113,7 +115,7 @@ class JBoxGS(JBPluginCloud):
             req = JBoxGS.connect().objects().get_media(bucket=bucket,
                                                        object=objname)
             fh = open(local_file, "wb")
-            downloader = MediaIoBaseDownload(fh, req, chunksize=4*1024*1024)
+            downloader = MediaIoBaseDownload(fh, req, chunksize=JBoxGS.CHUNK_SIZE*1024*1024)
             done = False
             num_retries = 0
             while not done:


### PR DESCRIPTION
Changed the chunk size from 4 MB to 64 MB.

##### Test:
Downloaded a file of size ~ 300 MB to a GCE instance from a bucket 10 times asynchronously.

|Chunk size (MB)|Average time taken (s)|
|-----------------------|------------------------------|
|4|16.73|
|64|3.94|

Did not observe significant changes in download time beyond 64 MB and below 4 MB.

##### Time for upload:
|Chunk size (MB)|Average time taken (s)|
|-----------------------|------------------------------|
|4|9.37|
|64|4.29|