### PR TITLE
Add a state parameter in oauth for better security

### DIFF
--- a/engine/src/juliabox/handlers/handler_base.py
+++ b/engine/src/juliabox/handlers/handler_base.py
@@ -26,6 +26,7 @@ class JBoxCookies(RequestHandler, LoggerMixin):
     COOKIE_SESS = 'jb_sess'
     COOKIE_INSTANCEID = 'jb_iid'
     COOKIE_LOADING = 'jb_loading'
+    COOKIE_STATE = 'jb_state'
 
     COOKIE_PFX_PORT = 'jp_'
     COOKIE_PORT_SHELL = 'shell'
@@ -41,6 +42,18 @@ class JBoxCookies(RequestHandler, LoggerMixin):
         self._loading_state = None
         self._valid_user = None
         self._valid_session = None
+
+    def set_state_cookie(self, state):
+        jbox_cookie = {'state': state}
+        coded = base64.b64encode(json.dumps(jbox_cookie))
+        self.set_cookie(JBoxCookies.COOKIE_STATE, coded)
+
+    def get_state_cookie(self):
+        jbox_cookie = self.get_cookie(JBoxCookies.COOKIE_STATE)
+        if jbox_cookie is None:
+            return None
+        jbox_cookie = json.loads(base64.b64decode(jbox_cookie))
+        return jbox_cookie['state']
 
     def set_authenticated(self, user_id):
         """ Marks user_id as authenticated with a cookie named COOKIE_AUTH (juliabox).

--- a/engine/src/juliabox/jbox_util.py
+++ b/engine/src/juliabox/jbox_util.py
@@ -6,11 +6,12 @@ import errno
 import hashlib
 import math
 import logging
+import string
 
 import isodate
 import httplib
 import errno
-from random import random
+import random
 
 def parse_iso_time(tm):
     if tm is not None:
@@ -318,7 +319,12 @@ def retry_on_errors(retries=10, backoff=2, max_sleep_time=32):
                         raise err
                     else:
                         sleep_time = min(backoff**nretry, max_sleep_time)
-                        time.sleep(sleep_time + random())
+                        time.sleep(sleep_time + random.random())
                 nretry += 1
         return func
     return g
+
+def gen_random_secret():
+    jb_secret = JBoxCfg.get('jbox_secret', '')
+    random_secret = ''.join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(10))
+    return hashlib.sha1(jb_secret + random_secret).hexdigest()


### PR DESCRIPTION
Generate a secret string from a secret provided in `jbox.user` and a randomly generated string.  This is saved in the client cookie and checked with the response from the OAuth request.

Added this feature to GitHub and LinkedIn authentication plugins.