### PR TITLE
Delete cookies on timeout before showing the logout dialog

### DIFF
--- a/webserver/www/assets/js/juliabox.js
+++ b/webserver/www/assets/js/juliabox.js
@@ -447,7 +447,7 @@ var JuliaBox = (function($, _, undefined){
                     $.removeCookie(it);
                 }
             }
-        }
+        },
     	
     	logout_at_browser: function () {
                         self.clear_cookies();

--- a/webserver/www/assets/js/juliabox.js
+++ b/webserver/www/assets/js/juliabox.js
@@ -440,13 +440,17 @@ var JuliaBox = (function($, _, undefined){
     	hide_inpage_alert: function () {
     		_msg_div.hide();
     	},
+
+        clear_cookies: function () {
+            for (var it in $.cookie()) {
+                if((it.indexOf("jb_") == 0) || (it.indexOf("jp_") == 0)) {
+                    $.removeCookie(it);
+                }
+            }
+        }
     	
     	logout_at_browser: function () {
-			for (var it in $.cookie()) {
-				if((it.indexOf("jb_") == 0) || (it.indexOf("jp_") == 0)) {
-					$.removeCookie(it);
-				}
-			}
+                        self.clear_cookies();
 			top.location.href = '/';
 			top.location.reload(true);
     	},
@@ -474,6 +478,7 @@ var JuliaBox = (function($, _, undefined){
 	    		if(pingfail) {
 	    		    msg += "<br/><br/>You may also get logged out if JuliaBox servers are not reachable from your browser <br/>" +
 	    		           "or you have too many JuliaBox windows open."
+                            self.clear_cookies();
 	    		}
 	    		else {
 	    		    self.do_logout();


### PR DESCRIPTION
The cookies will remain behind if the user does not dismiss the timeout alert and reloads the page.  This will cause invalid ping requests and render the session unusable.